### PR TITLE
Exit instead of panicking on X11 connection loss.

### DIFF
--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -673,7 +673,10 @@ impl ActiveEventLoop {
             .map_err(|err| {
                 // Handle loss of connection to the X server by exiting instead of panicking.
                 if let X11Error::Connection(_) = err {
-                    error!("Detected loss of connection to X server while reading window geometry; exiting application...");
+                    error!(
+                        "Detected loss of connection to X server while reading window geometry; \
+                        exiting application..."
+                    );
                     // Use exit code 1 to match the default Xlib I/O error handler.
                     std::process::exit(1);
                 }

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -675,7 +675,7 @@ impl ActiveEventLoop {
                 if let X11Error::Connection(_) = err {
                     error!(
                         "Detected loss of connection to X server while reading window geometry; \
-                        exiting application..."
+                         exiting application..."
                     );
                     // Use exit code 1 to match the default Xlib I/O error handler.
                     std::process::exit(1);

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -1242,7 +1242,10 @@ impl UnownedWindow {
             .map_err(|err| {
                 // Handle loss of connection to the X server by exiting instead of panicking.
                 if let X11Error::Connection(_) = err {
-                    error!("Detected loss of connection to X server while reading window geometry; exiting application...");
+                    error!(
+                        "Detected loss of connection to X server while reading window geometry; \
+                        exiting application..."
+                    );
                     // Use exit code 1 to match the default Xlib I/O error handler.
                     std::process::exit(1);
                 }

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -1244,7 +1244,7 @@ impl UnownedWindow {
                 if let X11Error::Connection(_) = err {
                     error!(
                         "Detected loss of connection to X server while reading window geometry; \
-                        exiting application..."
+                         exiting application..."
                     );
                     // Use exit code 1 to match the default Xlib I/O error handler.
                     std::process::exit(1);

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::{cmp, env};
 
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 use x11rb::connection::Connection;
 use x11rb::properties::{WmHints, WmSizeHints, WmSizeHintsSpecification};
 use x11rb::protocol::shape::SK;
@@ -1239,6 +1239,15 @@ impl UnownedWindow {
         // is BadWindow, and if the window handle is bad we have bigger problems.
         self.xconn
             .get_geometry(self.xwindow)
+            .map_err(|err| {
+                // Handle loss of connection to the X server by exiting instead of panicking.
+                if let X11Error::Connection(_) = err {
+                    error!("Detected loss of connection to X server while reading window geometry; exiting application...");
+                    // Use exit code 1 to match the default Xlib I/O error handler.
+                    std::process::exit(1);
+                }
+                err
+            })
             .map(|geo| (geo.width.into(), geo.height.into()))
             .unwrap()
     }


### PR DESCRIPTION
This checks for `X11Error::Connection(_)` in two places where we see errors in Sentry ([reading window size](https://warpdotdev.sentry.io/issues/5312715565/?project=5701177&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=30d&stream_index=0), [xinput handling](https://warpdotdev.sentry.io/issues/5312117098/?project=5658526&query=is%3Aunresolved+%22Connection%28IoError%22+%21stack.function%3Awinit%3A%3Aplatform_impl%3A%3Aplatform%3A%3AWindow%3A%3Ainner_size&referrer=issue-stream&statsPeriod=30d&stream_index=0)) and calls `std::process::exit(1)` instead of unwrapping the error.

This should have no meaningful user-visible impact (the app suddenly exits either way) but keeps these panics out of Sentry, as they're non-actionable and the application _should_ exit when it detects loss of its connection to the X server.