### PR TITLE
Workaround winit bug where events execute immediately

### DIFF
--- a/src/platform_impl/web/event_loop/proxy.rs
+++ b/src/platform_impl/web/event_loop/proxy.rs
@@ -17,7 +17,13 @@ impl<T: 'static> EventLoopProxy<T> {
 
     pub fn send_event(&self, event: T) -> Result<(), EventLoopClosed<T>> {
         self.sender.send(event).map_err(|SendError(event)| EventLoopClosed(event))?;
-        self.runner.wake();
+
+        // Workaround: the we should never be immediately executing new things on the event loop!
+        let runner = self.runner.clone();
+        wasm_bindgen_futures::spawn_local(async move {
+            runner.wake();
+        });
+
         Ok(())
     }
 }


### PR DESCRIPTION
Winit on web has a bug where the `EventLoopProxy` will _immediately_ call handlers for a custom event in `send_event` instead of scheduling it for the next event tick. This causes double-borrows of our `MutableAppContext`, which hard crashes the app. This is a bandaid fix which pushes those calls on the microtask queue instead.