### PR TITLE
Disable problematic debug assert 

### DIFF
--- a/src/platform_impl/web/web_sys/media_query_handle.rs
+++ b/src/platform_impl/web/web_sys/media_query_handle.rs
@@ -30,6 +30,7 @@ impl MediaQueryListHandle {
         Self { mql, closure }
     }
 
+    #[allow(dead_code)]
     pub fn mql(&self) -> &MediaQueryList {
         &self.mql
     }

--- a/src/platform_impl/web/web_sys/resize_scaling.rs
+++ b/src/platform_impl/web/web_sys/resize_scaling.rs
@@ -127,11 +127,14 @@ impl ResizeScaleInternal {
              (-webkit-device-pixel-ratio: {current_scale})",
         );
         let mql = MediaQueryListHandle::new(window, &media_query, closure);
-        debug_assert!(
-            mql.mql().matches(),
-            "created media query doesn't match, {current_scale} != {}",
-            super::scale_factor(window)
-        );
+        // TODO(PLAT-806): There's a winit/browser bug that causes this debug_assert
+        // to trigger when the print dialog is open. To prevent debug builds from
+        // panicking, we disable the debug_assert for now.
+        // debug_assert!(
+        //     mql.mql().matches(),
+        //     "created media query doesn't match, {current_scale} != {}",
+        //     super::scale_factor(window)
+        // );
         mql
     }
 


### PR DESCRIPTION
## Description

This debug assert is causing crashes in our debug Warp builds when the print dialog is opened. For now, we disable this debug assert until the underlying winit/browser bug is resolved.