### PR TITLE
prevent incorrect shifting of window when dragging onto monitor with different DPI

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -49,6 +49,8 @@ changelog entry.
 
 - On Web, fix `EventLoopProxy::send_event()` triggering event loop immediately
   when not called from inside the event loop. Now queues a microtask instead.
+- On Windows, prevent incorrect shifting when dragging window onto a monitor
+  with different DPI.
 
 ### Removed
 


### PR DESCRIPTION
This PR fixes this issue: https://github.com/rust-windowing/winit/issues/4041#issuecomment-2610856348

The code I deleted has a validation to check if the new window bounds which Windows is suggesting to move the monitor to is actually on the monitor which triggered the `WM_DPI_CHANGED` event. If that validation fails, it tried to move the window such that it will be on the monitor which triggered the `WM_DPI_CHANGED` event. However, this validation was buggy and was actually causing this bug. It was moving the window _off of_ the intended monitor. It seems this is no longer necessary. For example, [Chromium's DPI changed handler](https://github.com/chromium/chromium/blob/2b7390111f4987f8ab6781cebed91172d2b56464/ui/views/win/hwnd_message_handler.cc#L1904) does not contain an analogous check.

Hm... not sure why clippy is failing on code I haven't touched.. CI is all green on the PR against upstream which is based on upstream/master.

## Before

https://www.loom.com/share/aefc5dc1027a42fc8f462c23621ce9a5

## After

https://www.loom.com/share/81351dcb5938463c8bb60a66b2a0641b