### PR TITLE
Use the Tauri implementation of the DPI-change fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,6 +204,7 @@ features = [
 
 [target.'cfg(target_os = "windows")'.dependencies]
 unicode-segmentation = "1.7.1"
+windows-version = "0.1.1"
 
 [target.'cfg(target_os = "windows")'.dependencies.windows-sys]
 version = "0.52.0"

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -49,6 +49,8 @@ changelog entry.
 
 - On Web, fix `EventLoopProxy::send_event()` triggering event loop immediately
   when not called from inside the event loop. Now queues a microtask instead.
+- On Windows, prevent incorrect shifting when dragging window onto a monitor
+  with different DPI.
 
 ### Removed
 

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -49,8 +49,6 @@ changelog entry.
 
 - On Web, fix `EventLoopProxy::send_event()` triggering event loop immediately
   when not called from inside the event loop. Now queues a microtask instead.
-- On Windows, prevent incorrect shifting when dragging window onto a monitor
-  with different DPI.
 
 ### Removed
 

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -2196,103 +2196,110 @@ unsafe fn public_window_callback_inner(
             }
 
             let new_outer_rect: RECT;
-            {
-                let suggested_ul =
-                    (suggested_rect.left + margin_left, suggested_rect.top + margin_top);
+            if util::WIN_VERSION.build < 22000 {
+                // The window position needs adjustment on Windows 10.
+                {
+                    let suggested_ul =
+                        (suggested_rect.left + margin_left, suggested_rect.top + margin_top);
 
-                let mut conservative_rect = RECT {
-                    left: suggested_ul.0,
-                    top: suggested_ul.1,
-                    right: suggested_ul.0 + new_physical_inner_size.width as i32,
-                    bottom: suggested_ul.1 + new_physical_inner_size.height as i32,
-                };
-
-                conservative_rect = window_flags
-                    .adjust_rect(window, conservative_rect)
-                    .unwrap_or(conservative_rect);
-
-                // If we're dragging the window, offset the window so that the cursor's
-                // relative horizontal position in the title bar is preserved.
-                if dragging_window {
-                    let bias = {
-                        let cursor_pos = {
-                            let mut pos = unsafe { mem::zeroed() };
-                            unsafe { GetCursorPos(&mut pos) };
-                            pos
-                        };
-                        let suggested_cursor_horizontal_ratio = (cursor_pos.x - suggested_rect.left)
-                            as f64
-                            / (suggested_rect.right - suggested_rect.left) as f64;
-
-                        (cursor_pos.x
-                            - (suggested_cursor_horizontal_ratio
-                                * (conservative_rect.right - conservative_rect.left) as f64)
-                                as i32)
-                            - conservative_rect.left
+                    let mut conservative_rect = RECT {
+                        left: suggested_ul.0,
+                        top: suggested_ul.1,
+                        right: suggested_ul.0 + new_physical_inner_size.width as i32,
+                        bottom: suggested_ul.1 + new_physical_inner_size.height as i32,
                     };
-                    conservative_rect.left += bias;
-                    conservative_rect.right += bias;
-                }
 
-                // Check to see if the new window rect is on the monitor with the new DPI factor.
-                // If it isn't, offset the window so that it is.
-                let new_dpi_monitor = unsafe { MonitorFromWindow(window, MONITOR_DEFAULTTONULL) };
-                let conservative_rect_monitor =
-                    unsafe { MonitorFromRect(&conservative_rect, MONITOR_DEFAULTTONULL) };
-                new_outer_rect = if conservative_rect_monitor == new_dpi_monitor {
-                    conservative_rect
-                } else {
-                    let get_monitor_rect = |monitor| {
-                        let mut monitor_info = MONITORINFO {
-                            cbSize: mem::size_of::<MONITORINFO>() as _,
-                            ..unsafe { mem::zeroed() }
+                    conservative_rect = window_flags
+                        .adjust_rect(window, conservative_rect)
+                        .unwrap_or(conservative_rect);
+
+                    // If we're dragging the window, offset the window so that the cursor's
+                    // relative horizontal position in the title bar is preserved.
+                    if dragging_window {
+                        let bias = {
+                            let cursor_pos = {
+                                let mut pos = unsafe { mem::zeroed() };
+                                unsafe { GetCursorPos(&mut pos) };
+                                pos
+                            };
+                            let suggested_cursor_horizontal_ratio =
+                                (cursor_pos.x - suggested_rect.left) as f64
+                                    / (suggested_rect.right - suggested_rect.left) as f64;
+
+                            (cursor_pos.x
+                                - (suggested_cursor_horizontal_ratio
+                                    * (conservative_rect.right - conservative_rect.left) as f64)
+                                    as i32)
+                                - conservative_rect.left
                         };
-                        unsafe { GetMonitorInfoW(monitor, &mut monitor_info) };
-                        monitor_info.rcMonitor
-                    };
-                    let wrong_monitor = conservative_rect_monitor;
-                    let wrong_monitor_rect = get_monitor_rect(wrong_monitor);
-                    let new_monitor_rect = get_monitor_rect(new_dpi_monitor);
-
-                    // The direction to nudge the window in to get the window onto the monitor with
-                    // the new DPI factor. We calculate this by seeing which monitor edges are
-                    // shared and nudging away from the wrong monitor based on those.
-                    #[allow(clippy::bool_to_int_with_if)]
-                    let delta_nudge_to_dpi_monitor = (
-                        if wrong_monitor_rect.left == new_monitor_rect.right {
-                            -1
-                        } else if wrong_monitor_rect.right == new_monitor_rect.left {
-                            1
-                        } else {
-                            0
-                        },
-                        if wrong_monitor_rect.bottom == new_monitor_rect.top {
-                            1
-                        } else if wrong_monitor_rect.top == new_monitor_rect.bottom {
-                            -1
-                        } else {
-                            0
-                        },
-                    );
-
-                    let abort_after_iterations = new_monitor_rect.right - new_monitor_rect.left
-                        + new_monitor_rect.bottom
-                        - new_monitor_rect.top;
-                    for _ in 0..abort_after_iterations {
-                        conservative_rect.left += delta_nudge_to_dpi_monitor.0;
-                        conservative_rect.right += delta_nudge_to_dpi_monitor.0;
-                        conservative_rect.top += delta_nudge_to_dpi_monitor.1;
-                        conservative_rect.bottom += delta_nudge_to_dpi_monitor.1;
-
-                        if unsafe { MonitorFromRect(&conservative_rect, MONITOR_DEFAULTTONULL) }
-                            == new_dpi_monitor
-                        {
-                            break;
-                        }
+                        conservative_rect.left += bias;
+                        conservative_rect.right += bias;
                     }
 
-                    conservative_rect
-                };
+                    // Check to see if the new window rect is on the monitor with the new DPI factor.
+                    // If it isn't, offset the window so that it is.
+                    let new_dpi_monitor =
+                        unsafe { MonitorFromWindow(window, MONITOR_DEFAULTTONULL) };
+                    let conservative_rect_monitor =
+                        unsafe { MonitorFromRect(&conservative_rect, MONITOR_DEFAULTTONULL) };
+                    new_outer_rect = if conservative_rect_monitor == new_dpi_monitor {
+                        conservative_rect
+                    } else {
+                        let get_monitor_rect = |monitor| {
+                            let mut monitor_info = MONITORINFO {
+                                cbSize: mem::size_of::<MONITORINFO>() as _,
+                                ..unsafe { mem::zeroed() }
+                            };
+                            unsafe { GetMonitorInfoW(monitor, &mut monitor_info) };
+                            monitor_info.rcMonitor
+                        };
+                        let wrong_monitor = conservative_rect_monitor;
+                        let wrong_monitor_rect = get_monitor_rect(wrong_monitor);
+                        let new_monitor_rect = get_monitor_rect(new_dpi_monitor);
+
+                        // The direction to nudge the window in to get the window onto the monitor with
+                        // the new DPI factor. We calculate this by seeing which monitor edges are
+                        // shared and nudging away from the wrong monitor based on those.
+                        #[allow(clippy::bool_to_int_with_if)]
+                        let delta_nudge_to_dpi_monitor = (
+                            if wrong_monitor_rect.left == new_monitor_rect.right {
+                                -1
+                            } else if wrong_monitor_rect.right == new_monitor_rect.left {
+                                1
+                            } else {
+                                0
+                            },
+                            if wrong_monitor_rect.bottom == new_monitor_rect.top {
+                                1
+                            } else if wrong_monitor_rect.top == new_monitor_rect.bottom {
+                                -1
+                            } else {
+                                0
+                            },
+                        );
+
+                        let abort_after_iterations = new_monitor_rect.right - new_monitor_rect.left
+                            + new_monitor_rect.bottom
+                            - new_monitor_rect.top;
+                        for _ in 0..abort_after_iterations {
+                            conservative_rect.left += delta_nudge_to_dpi_monitor.0;
+                            conservative_rect.right += delta_nudge_to_dpi_monitor.0;
+                            conservative_rect.top += delta_nudge_to_dpi_monitor.1;
+                            conservative_rect.bottom += delta_nudge_to_dpi_monitor.1;
+
+                            if unsafe { MonitorFromRect(&conservative_rect, MONITOR_DEFAULTTONULL) }
+                                == new_dpi_monitor
+                            {
+                                break;
+                            }
+                        }
+
+                        conservative_rect
+                    };
+                }
+            } else {
+                // The suggested position is fine w/o adjustment on Windows 11.
+                new_outer_rect = suggested_rect
             }
 
             unsafe {
@@ -2441,7 +2448,7 @@ unsafe extern "system" fn thread_event_target_callback(
     if userdata_removed {
         drop(userdata);
     } else {
-        Box::into_raw(userdata);
+        Box::leak(userdata);
     }
     result
 }

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -18,8 +18,8 @@ use crate::utils::Lazy;
 use windows_sys::Win32::Devices::HumanInterfaceDevice::MOUSE_MOVE_RELATIVE;
 use windows_sys::Win32::Foundation::{HWND, LPARAM, LRESULT, POINT, RECT, WPARAM};
 use windows_sys::Win32::Graphics::Gdi::{
-    MonitorFromRect, RedrawWindow, ScreenToClient, ValidateRect, MONITOR_DEFAULTTONULL,
-    RDW_INTERNALPAINT, SC_SCREENSAVE,
+    GetMonitorInfoW, MonitorFromRect, MonitorFromWindow, RedrawWindow, ScreenToClient,
+    ValidateRect, MONITORINFO, MONITOR_DEFAULTTONULL, RDW_INTERNALPAINT, SC_SCREENSAVE,
 };
 use windows_sys::Win32::System::Ole::RevokeDragDrop;
 use windows_sys::Win32::System::Threading::{GetCurrentThreadId, INFINITE};
@@ -2234,7 +2234,65 @@ unsafe fn public_window_callback_inner(
                     conservative_rect.right += bias;
                 }
 
-                new_outer_rect = conservative_rect;
+                // Check to see if the new window rect is on the monitor with the new DPI factor.
+                // If it isn't, offset the window so that it is.
+                let new_dpi_monitor = unsafe { MonitorFromWindow(window, MONITOR_DEFAULTTONULL) };
+                let conservative_rect_monitor =
+                    unsafe { MonitorFromRect(&conservative_rect, MONITOR_DEFAULTTONULL) };
+                new_outer_rect = if conservative_rect_monitor == new_dpi_monitor {
+                    conservative_rect
+                } else {
+                    let get_monitor_rect = |monitor| {
+                        let mut monitor_info = MONITORINFO {
+                            cbSize: mem::size_of::<MONITORINFO>() as _,
+                            ..unsafe { mem::zeroed() }
+                        };
+                        unsafe { GetMonitorInfoW(monitor, &mut monitor_info) };
+                        monitor_info.rcMonitor
+                    };
+                    let wrong_monitor = conservative_rect_monitor;
+                    let wrong_monitor_rect = get_monitor_rect(wrong_monitor);
+                    let new_monitor_rect = get_monitor_rect(new_dpi_monitor);
+
+                    // The direction to nudge the window in to get the window onto the monitor with
+                    // the new DPI factor. We calculate this by seeing which monitor edges are
+                    // shared and nudging away from the wrong monitor based on those.
+                    #[allow(clippy::bool_to_int_with_if)]
+                    let delta_nudge_to_dpi_monitor = (
+                        if wrong_monitor_rect.left == new_monitor_rect.right {
+                            -1
+                        } else if wrong_monitor_rect.right == new_monitor_rect.left {
+                            1
+                        } else {
+                            0
+                        },
+                        if wrong_monitor_rect.bottom == new_monitor_rect.top {
+                            1
+                        } else if wrong_monitor_rect.top == new_monitor_rect.bottom {
+                            -1
+                        } else {
+                            0
+                        },
+                    );
+
+                    let abort_after_iterations = new_monitor_rect.right - new_monitor_rect.left
+                        + new_monitor_rect.bottom
+                        - new_monitor_rect.top;
+                    for _ in 0..abort_after_iterations {
+                        conservative_rect.left += delta_nudge_to_dpi_monitor.0;
+                        conservative_rect.right += delta_nudge_to_dpi_monitor.0;
+                        conservative_rect.top += delta_nudge_to_dpi_monitor.1;
+                        conservative_rect.bottom += delta_nudge_to_dpi_monitor.1;
+
+                        if unsafe { MonitorFromRect(&conservative_rect, MONITOR_DEFAULTTONULL) }
+                            == new_dpi_monitor
+                        {
+                            break;
+                        }
+                    }
+
+                    conservative_rect
+                };
             }
 
             unsafe {
@@ -2383,7 +2441,7 @@ unsafe extern "system" fn thread_event_target_callback(
     if userdata_removed {
         drop(userdata);
     } else {
-        Box::leak(userdata);
+        Box::into_raw(userdata);
     }
     result
 }

--- a/src/platform_impl/windows/util.rs
+++ b/src/platform_impl/windows/util.rs
@@ -3,6 +3,7 @@ use std::iter::once;
 use std::ops::BitAnd;
 use std::os::windows::prelude::{OsStrExt, OsStringExt};
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::LazyLock;
 use std::{io, mem, ptr};
 
 use crate::utils::Lazy;
@@ -25,6 +26,9 @@ use windows_sys::Win32::UI::WindowsAndMessaging::{
 };
 
 use crate::window::CursorIcon;
+
+pub static WIN_VERSION: LazyLock<windows_version::OsVersion> =
+    LazyLock::new(windows_version::OsVersion::current);
 
 pub fn encode_wide(string: impl AsRef<OsStr>) -> Vec<u16> {
     string.as_ref().encode_wide().chain(once(0)).collect()


### PR DESCRIPTION
This PR is another attempt at #8. Instead of deleting that check altogether, it is guarded by a Windows version check. Tauri noticed in tauri-apps/tao#1056 that this is still necessary in Windows 10. In this commit i've reverted my fix and applied theirs on top.

It's a little easier to see using [this semantic diff tool](https://app.semanticdiff.com/gh/tauri-apps/tao/pull/1056/changes#src/platform_impl/windows/event_loop.rs?ignore_comments=false) that they just wrapped a big block of code in an if-else.

Using that same tool to visualize this diff: https://app.semanticdiff.com/gh/warpdotdev/winit/pull/10/changes#src/platform_impl/windows/event_loop.rs?ignore_comments=false