### PR TITLE
Fix bad merge in canvas resize handling

### DIFF
--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -570,7 +570,7 @@ impl ActiveEventLoop {
                             window_id: RootWindowId(id),
                             event: WindowEvent::Resized(new_size),
                         });
-                        canvas.request_animation_frame();
+                        canvas.borrow().request_animation_frame();
                     }
                 }
             },


### PR DESCRIPTION
Updating to `v0.30.13` in #13 broke compilation due to a clash between #11 and upstream rust-windowing/winit#3790.

To prevent double-borrows, we changed the scope of the canvas borrow, making it unavailable when calling `requestAnimationFrame`. The fix is pretty straightforward - we re-borrow the canvas briefly to request re-rendering.

Tested by running Warp-on-Web locally.

- [x] Tested on all platforms changed
- [ ] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
