### PR TITLE
windows: fix layout-switch freeze (Punto Switcher) via WM_INPUTLANGCHANGE

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -217,6 +217,11 @@ changelog entry.
 
 ### Fixed
 
+- On Windows, fix deadlock when switching keyboard layout via tools like PuntoSwitcher or IME
+  switchers. The `LAYOUT_CACHE` mutex was held across a `PeekMessageW` call in the `WM_KEYDOWN`
+  handler, which could dispatch re-entrant messages that tried to re-acquire the same lock.
+- On Windows, handle `WM_INPUTLANGCHANGE` explicitly to refresh the layout cache and avoid
+  re-entrant deadlocks through `DefWindowProc`.
 - On Orbital, `MonitorHandle::name()` now returns `None` instead of a dummy name.
 - On iOS, fixed `SurfaceResized` and `Window::surface_size` not reporting the size of the actual surface.
 - On macOS, fixed the scancode conversion for audio volume keys.

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -217,11 +217,9 @@ changelog entry.
 
 ### Fixed
 
-- On Windows, fix deadlock when switching keyboard layout via tools like PuntoSwitcher or IME
-  switchers. The `LAYOUT_CACHE` mutex was held across a `PeekMessageW` call in the `WM_KEYDOWN`
-  handler, which could dispatch re-entrant messages that tried to re-acquire the same lock.
-- On Windows, handle `WM_INPUTLANGCHANGE` explicitly to refresh the layout cache and avoid
-  re-entrant deadlocks through `DefWindowProc`.
+- On Windows, fix freeze when switching keyboard layout with tools like Punto Switcher. The
+  `WM_INPUTLANGCHANGE` message is now handled to refresh the cached keyboard layout, while still
+  deferring to `DefWindowProc` for normal propagation.
 - On Orbital, `MonitorHandle::name()` now returns `None` instead of a dummy name.
 - On iOS, fixed `SurfaceResized` and `Window::surface_size` not reporting the size of the actual surface.
 - On macOS, fixed the scancode conversion for audio volume keys.

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1570,19 +1570,18 @@ unsafe fn public_window_callback_inner(
         },
 
         WM_INPUTLANGCHANGE => {
-            // Refresh the layout cache so subsequent key events use the new
-            // layout. This message is sent by Windows (or tools like
-            // PuntoSwitcher) when the keyboard layout changes. We handle it
-            // explicitly to avoid re-entrant deadlocks: without this handler
-            // the message falls through to DefWindowProc which may
-            // synchronously dispatch IME messages while LAYOUT_CACHE is held
-            // by a parent WNDPROC frame.
+            // Refresh the cached keyboard layout for the newly activated input
+            // language. This message is sent (by Windows or by layout switchers
+            // such as Punto Switcher) after the layout changes. Refreshing the
+            // cache here prevents a freeze that otherwise occurs when switching
+            // layout via such tools. We still defer to `DefWindowProc` so the
+            // message keeps propagating to first-level child windows, as the
+            // Win32 documentation requires.
             {
                 let mut layouts = LAYOUT_CACHE.lock().unwrap();
                 layouts.get_current_layout();
             }
-            update_modifiers(window, userdata);
-            result = ProcResult::Value(1);
+            result = ProcResult::DefWindowProc(wparam);
         },
 
         // this is necessary for us to maintain minimize/restore state

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -49,12 +49,12 @@ use windows_sys::Win32::UI::WindowsAndMessaging::{
     WMSZ_BOTTOMRIGHT, WMSZ_LEFT, WMSZ_RIGHT, WMSZ_TOP, WMSZ_TOPLEFT, WMSZ_TOPRIGHT,
     WM_CAPTURECHANGED, WM_CLOSE, WM_CREATE, WM_DESTROY, WM_DPICHANGED, WM_ENTERSIZEMOVE,
     WM_EXITSIZEMOVE, WM_GETMINMAXINFO, WM_IME_COMPOSITION, WM_IME_ENDCOMPOSITION,
-    WM_IME_SETCONTEXT, WM_IME_STARTCOMPOSITION, WM_INPUT, WM_KEYDOWN, WM_KEYUP, WM_KILLFOCUS,
-    WM_LBUTTONDOWN, WM_LBUTTONUP, WM_MBUTTONDOWN, WM_MBUTTONUP, WM_MENUCHAR, WM_MOUSEHWHEEL,
-    WM_MOUSEMOVE, WM_MOUSEWHEEL, WM_NCACTIVATE, WM_NCCALCSIZE, WM_NCCREATE, WM_NCDESTROY,
-    WM_NCLBUTTONDOWN, WM_PAINT, WM_POINTERDOWN, WM_POINTERUP, WM_POINTERUPDATE, WM_RBUTTONDOWN,
-    WM_RBUTTONUP, WM_SETCURSOR, WM_SETFOCUS, WM_SETTINGCHANGE, WM_SIZE, WM_SIZING, WM_SYSCOMMAND,
-    WM_SYSKEYDOWN, WM_SYSKEYUP, WM_TOUCH, WM_WINDOWPOSCHANGED, WM_WINDOWPOSCHANGING,
+    WM_IME_SETCONTEXT, WM_IME_STARTCOMPOSITION, WM_INPUT, WM_INPUTLANGCHANGE, WM_KEYDOWN, WM_KEYUP,
+    WM_KILLFOCUS, WM_LBUTTONDOWN, WM_LBUTTONUP, WM_MBUTTONDOWN, WM_MBUTTONUP, WM_MENUCHAR,
+    WM_MOUSEHWHEEL, WM_MOUSEMOVE, WM_MOUSEWHEEL, WM_NCACTIVATE, WM_NCCALCSIZE, WM_NCCREATE,
+    WM_NCDESTROY, WM_NCLBUTTONDOWN, WM_PAINT, WM_POINTERDOWN, WM_POINTERUP, WM_POINTERUPDATE,
+    WM_RBUTTONDOWN, WM_RBUTTONUP, WM_SETCURSOR, WM_SETFOCUS, WM_SETTINGCHANGE, WM_SIZE, WM_SIZING,
+    WM_SYSCOMMAND, WM_SYSKEYDOWN, WM_SYSKEYUP, WM_TOUCH, WM_WINDOWPOSCHANGED, WM_WINDOWPOSCHANGING,
     WM_XBUTTONDOWN, WM_XBUTTONUP, WNDCLASSEXW, WS_EX_LAYERED, WS_EX_NOACTIVATE, WS_EX_TOOLWINDOW,
     WS_EX_TRANSPARENT, WS_OVERLAPPED, WS_POPUP, WS_VISIBLE,
 };
@@ -1567,6 +1567,22 @@ unsafe fn public_window_callback_inner(
             // Hide composing text drawn by IME.
             let wparam = wparam & (!ISC_SHOWUICOMPOSITIONWINDOW as usize);
             result = ProcResult::DefWindowProc(wparam);
+        },
+
+        WM_INPUTLANGCHANGE => {
+            // Refresh the layout cache so subsequent key events use the new
+            // layout. This message is sent by Windows (or tools like
+            // PuntoSwitcher) when the keyboard layout changes. We handle it
+            // explicitly to avoid re-entrant deadlocks: without this handler
+            // the message falls through to DefWindowProc which may
+            // synchronously dispatch IME messages while LAYOUT_CACHE is held
+            // by a parent WNDPROC frame.
+            {
+                let mut layouts = LAYOUT_CACHE.lock().unwrap();
+                layouts.get_current_layout();
+            }
+            update_modifiers(window, userdata);
+            result = ProcResult::Value(1);
         },
 
         // this is necessary for us to maintain minimize/restore state

--- a/src/platform_impl/windows/keyboard.rs
+++ b/src/platform_impl/windows/keyboard.rs
@@ -111,6 +111,8 @@ impl KeyEventBuilder {
                     let pending_token = self.pending.add_pending();
                     *result = ProcResult::Value(0);
 
+                    let next_msg = next_kbd_msg(hwnd);
+
                     let mut layouts = LAYOUT_CACHE.lock().unwrap();
                     let mut finished_event_info = Some(PartialKeyEventInfo::from_message(
                         wparam,
@@ -118,15 +120,6 @@ impl KeyEventBuilder {
                         ElementState::Pressed,
                         &mut layouts,
                     ));
-                    // We MUST release the layout lock before calling `next_kbd_msg`,
-                    // otherwise PeekMessageW may dispatch re-entrant messages (e.g.
-                    // WM_INPUTLANGCHANGE from PuntoSwitcher or other IME switchers)
-                    // that try to re-acquire LAYOUT_CACHE on the same thread, causing
-                    // a deadlock.
-                    drop(layouts);
-
-                    let next_msg = next_kbd_msg(hwnd);
-
                     let mut event_info = self.event_info.lock().unwrap();
                     *event_info = None;
                     if let Some(next_msg) = next_msg {
@@ -140,7 +133,6 @@ impl KeyEventBuilder {
                             // store the partial information, and add to it in the upcoming events
                             *event_info = finished_event_info.take();
                         } else {
-                            let mut layouts = LAYOUT_CACHE.lock().unwrap();
                             let (_, layout) = layouts.get_current_layout();
                             let is_fake = {
                                 let curr_event = finished_event_info.as_ref().unwrap();

--- a/src/platform_impl/windows/keyboard.rs
+++ b/src/platform_impl/windows/keyboard.rs
@@ -111,8 +111,6 @@ impl KeyEventBuilder {
                     let pending_token = self.pending.add_pending();
                     *result = ProcResult::Value(0);
 
-                    let next_msg = next_kbd_msg(hwnd);
-
                     let mut layouts = LAYOUT_CACHE.lock().unwrap();
                     let mut finished_event_info = Some(PartialKeyEventInfo::from_message(
                         wparam,
@@ -120,6 +118,15 @@ impl KeyEventBuilder {
                         ElementState::Pressed,
                         &mut layouts,
                     ));
+                    // We MUST release the layout lock before calling `next_kbd_msg`,
+                    // otherwise PeekMessageW may dispatch re-entrant messages (e.g.
+                    // WM_INPUTLANGCHANGE from PuntoSwitcher or other IME switchers)
+                    // that try to re-acquire LAYOUT_CACHE on the same thread, causing
+                    // a deadlock.
+                    drop(layouts);
+
+                    let next_msg = next_kbd_msg(hwnd);
+
                     let mut event_info = self.event_info.lock().unwrap();
                     *event_info = None;
                     if let Some(next_msg) = next_msg {
@@ -133,6 +140,7 @@ impl KeyEventBuilder {
                             // store the partial information, and add to it in the upcoming events
                             *event_info = finished_event_info.take();
                         } else {
+                            let mut layouts = LAYOUT_CACHE.lock().unwrap();
                             let (_, layout) = layouts.get_current_layout();
                             let is_fake = {
                                 let curr_event = finished_event_info.as_ref().unwrap();


### PR DESCRIPTION
## Summary

Fixes a freeze that affects Warp (and any winit app) on Windows when the keyboard layout is switched by tools like **Punto Switcher**.

> **Note:** this PR was revised after capturing a minidump of the frozen process. The original explanation (a `LAYOUT_CACHE` mutex deadlock) was **wrong** — see "Root cause" below. The keyboard.rs change from the first revision has been dropped.

## Root cause (from a minidump of the frozen process)

A full dump was taken with procdump on the frozen window (original, unpatched code) and analyzed with `minidump-stackwalk` using symbols generated from the local system DLLs (so x64 unwind/CFI is exact).

Reliable top of the main thread:

```
0  win32u.dll!NtUserMsgWaitForMultipleObjectsEx        (instruction pointer)
1  winit::...::event_loop::wait_for_messages_impl       (Found by: call frame info)
2  user32.dll!CallNextHookEx
3  user32.dll!...
```

- The thread is blocked in **`MsgWaitForMultipleObjectsEx`** — winit's event-loop wait (`wait_for_messages_impl`) — **re-entered** during message dispatch.
- **`pshook64.dll`** (Punto Switcher's global hook, `%LOCALAPPDATA%\Yandex\Punto Switcher\pshook64.dll`) is injected into the process and present on the stack (`CallNextHookEx`), i.e. it runs on our thread during dispatch.
- **No mutex / `LAYOUT_CACHE` / `WaitOnAddress` frames anywhere.**

So this is a **re-entrant Win32 message-loop wait** mediated by Punto Switcher's hook, **not** a Rust mutex self-deadlock. (Thanks @acarl005 for pushing back — the original mutex explanation was inconsistent with the code, and the dump confirms it.)

## Fix

Handle `WM_INPUTLANGCHANGE` to refresh the cached keyboard layout, then defer to `DefWindowProc` (kept, per the [Win32 docs](https://learn.microsoft.com/en-us/windows/win32/winmsg/wm-inputlangchange), so the message still propagates to first-level child windows).

```rust
WM_INPUTLANGCHANGE => {
    { let mut layouts = LAYOUT_CACHE.lock().unwrap(); layouts.get_current_layout(); }
    result = ProcResult::DefWindowProc(wparam);
}
```

## Testing (Windows 11 + Punto Switcher)

Built the winit test app for `x86_64-pc-windows-gnu` and exercised real Punto Switcher layout switches (English ↔ Russian, confirmed by alphabet changes in the key log). Isolation variants:

| Variant | `WM_INPUTLANGCHANGE` handler | Result |
|---|---|---|
| original (no handler) | — | **freezes** (dump captured) |
| keyboard.rs reorder only | — | still freezes (dropped) |
| refresh + `update_modifiers` + `Value(1)` (swallow) | skips DefWindowProc | no freeze |
| **refresh + `DefWindowProc`** (this PR) | keeps DefWindowProc | **no freeze** |
| refresh only + `DefWindowProc`, no `update_modifiers` | keeps DefWindowProc | no freeze |

So the **layout-cache refresh** is the minimal change that stops the freeze; swallowing the message and `update_modifiers` are not needed.

**Honest limitation:** we isolated the operative change empirically and proved what it is *not* (a mutex deadlock), but the precise reason a cache refresh prevents the re-entrant wait is not fully traced (Punto Switcher's hook is closed-source). The dump at the freeze point shows no layout-loading frames.

## Checklist

- [x] Tested on Windows (the only platform changed)
- [x] Added a `changelog` entry
- [x] `DefWindowProc` retained for child-window propagation